### PR TITLE
Fix markdown table example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Will render as -
 
 ```markdown
 | Name           | Status        |
-|--------------------------------|
+|----------------|---------------|
 | Test 1         | pass          |
 | Test 2         | pass          |
 | Test 3         | fail          |
@@ -60,7 +60,7 @@ Will render as -
 Will render as -
 
 | Name           | Status        |
-|--------------------------------|
+|----------------|---------------|
 | Test 1         | pass          |
 | Test 2         | pass          |
 | Test 3         | fail          |


### PR DESCRIPTION
The table example in the readme doesn't render as a table because it's missing a `|` in the separator between the headers and the body.

Before | After
--- | ---
![image](https://github.com/travis-bradbury/commerce-docs/assets/3623162/e6f5b22a-fc30-434f-8aec-2b36cbe9f0a1) |  ![image](https://github.com/travis-bradbury/commerce-docs/assets/3623162/c8c9c9e2-c91a-4754-aa0f-5bbb23831baa)

The example section indicates it should be rewritten. Perhaps instead of fixing examples, the section should be replaced with a link to the MkDocs markdown documentation, https://www.mkdocs.org/user-guide/writing-your-docs/#writing-with-markdown.