### PR TITLE
Rename deprecated has_order_summary to has_sidebar in code recipe

### DIFF
--- a/docs/v2/developer-guide/checkout/checkout.md
+++ b/docs/v2/developer-guide/checkout/checkout.md
@@ -82,12 +82,12 @@ Lets create a module that will do this.
         'payment' => [
             'label' => $this->t('Payment'),
             'next_label' => $this->t('Pay and complete purchase'),
-            'has_order_summary' => FALSE,
+            'has_sidebar' => FALSE,
         ],
         'complete' => [
             'label' => $this->t('Complete'),
             'next_label' => $this->t('Pay and complete purchase'),
-            'has_order_summary' => FALSE,
+            'has_sidebar' => FALSE,
         ],
         ];
     ```
@@ -157,11 +157,11 @@ Lets create a module that will do this.
             'login' => [
                 'label' => $this->t('Login'),
                 'previous_label' => $this->t('Return to login'),
-                'has_order_summary' => FALSE,
+                'has_sidebar' => FALSE,
             ],
             'review' => [
                 'label' => $this->t('Review'),
-                'has_order_summary' => TRUE,
+                'has_sidebar' => TRUE,
             ],
             ] + parent::getSteps();
         }


### PR DESCRIPTION
In checkout flow sidebar visibility depend on the value of has_sidebar instead of has_order_summary. https://www.drupal.org/project/commerce/issues/2863051