### PR TITLE
Replace Mailhog reference with Mailpit

### DIFF
--- a/docs/v2/developer-guide/core/html_emails.md
+++ b/docs/v2/developer-guide/core/html_emails.md
@@ -10,4 +10,4 @@ You can find more information on how to send HTML emails with Symfony mailer on 
 
 The Drupal.org documentation handbook has a great article for working with email in a development and testing environment: [https://www.drupal.org/docs/develop/local-server-setup/managing-mail-handling-for-development-or-testing](https://www.drupal.org/docs/develop/local-server-setup/managing-mail-handling-for-development-or-testing)
 
-The Drupal Commerce team recommends using [Mailhog](https://github.com/mailhog/MailHog) for local email testing and development. [DrupalVM will send emails to it by default](http://docs.drupalvm.com/en/latest/extras/mailhog/) and it is easily installed locally or through a [Docker container](https://hub.docker.com/r/mailhog/mailhog/).
+The Drupal Commerce team recommends using [Mailpit](https://mailpit.axllent.org/) for local email testing and development. [DDEV will send emails to it by default](https://ddev.readthedocs.io/en/stable/users/usage/developer-tools/#email-capture-and-review-mailpit).


### PR DESCRIPTION
Mailhog was replaced with Mailpit. Furthermore, DDEV is now recommended local development environment over DrupalVM. This PR updates references to DrupalVM and Mailhog with their corresponding replacements.