### PR TITLE
Update code-recipes.md

### DIFF
--- a/docs/v2/developer-guide/stores/code-recipes.md
+++ b/docs/v2/developer-guide/stores/code-recipes.md
@@ -61,8 +61,9 @@ taxonomy:
         $store->save();
 
         // If needed, this sets the store as the default store.
-        $store_storage = \Drupal::service('entity_type.manager')->getStorage('commerce_store');
-        $store_storage->markAsDefault($store);
+        $store->setDefault(TRUE);
+        $store->save();
+
     
     ```
 


### PR DESCRIPTION
function markAsDefault is @deprecated in commerce:8.x-2.16 and is removed from commerce:3.x.