### PR TITLE
Add blank line between summary paragraph and list

### DIFF
--- a/docs/v2/developer-guide/recurring/subscriptions.md
+++ b/docs/v2/developer-guide/recurring/subscriptions.md
@@ -94,6 +94,7 @@ Next, `ensureOrder()` finishes up by saving the recurring order item and the rec
 <h3>Summary</h3>
 
 Here's an overview of "who did what" when the OrderSubscriber's `onPlace()` method was triggered by the `commerce_order.place.pre_transition` event:
+
 1. SubscriptionStorage:
     * create subscription
     * trigger `onSubscriptionCreate()` (SubscriptionType plugin method)


### PR DESCRIPTION
This commit resolves a formatting issue by adding a blank line between the Summary paragraph of the Subscriptions developer guide and the first list item immediately following it.

![blank-line](https://github.com/user-attachments/assets/6ed8024b-9d9a-40f3-9070-dfcd5fbd8396)
